### PR TITLE
Fixed Dependency Versions, Added a React-Router Decorator, Made Breacrumb use the Link component

### DIFF
--- a/.storybook/decorators/react-router.js
+++ b/.storybook/decorators/react-router.js
@@ -1,0 +1,36 @@
+import React, { useEffect } from "react";
+import { MemoryRouter, Route } from "react-router-dom";
+import { action } from "@storybook/addon-actions";
+
+const HistorySubscriber = ({ history, children }) => {
+  useEffect(() => {
+    const unlisten = history.listen((location, historyAction) => {
+      action(historyAction ? historyAction : location.action)(
+        location.pathname
+      );
+    });
+    return () => {
+      unlisten();
+    };
+  }, []);
+
+  return children;
+};
+
+const StoryRouter = ({ children, ...routerProps }) => {
+  return (
+    <MemoryRouter {...routerProps}>
+      <Route
+        render={({ history }) => (
+          <HistorySubscriber history={history}>{children}</HistorySubscriber>
+        )}
+      />
+    </MemoryRouter>
+  );
+};
+
+export const reactRouterDecorator = (story) => (
+  <StoryRouter initialEntries={["/"]}>{story()}</StoryRouter>
+);
+
+export default reactRouterDecorator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8556,11 +8556,16 @@
       "dev": true
     },
     "history": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
-      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "requires": {
-        "@babel/runtime": "^7.7.6"
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
       }
     },
     "hmac-drbg": {
@@ -8578,7 +8583,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       },
@@ -8586,8 +8590,7 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -9994,6 +9997,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -12173,20 +12185,54 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.0.2.tgz",
-      "integrity": "sha512-8/Wm3Ed8t7TuedXjAvV39+c8j0vwrI5qVsYqjFr5WkJjsJpEvNSoLRUbtqSEYzqaTUj1IV+sbPJxvO+accvU0Q==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
+      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
       "requires": {
-        "history": "^5.1.0"
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
       }
     },
     "react-router-dom": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz",
-      "integrity": "sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
+      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
       "requires": {
-        "history": "^5.1.0",
-        "react-router": "6.0.2"
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-router-hash-link": {
@@ -12647,6 +12693,11 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14152,6 +14203,16 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -14764,6 +14825,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.0.6",
     "@rollup/plugin-typescript": "^8.3.0",
-    "@storybook/addon-a11y": "^6.3.12",
-    "@storybook/addon-actions": "^6.3.12",
-    "@storybook/addon-essentials": "^6.3.12",
+    "@storybook/addon-a11y": "~6.3.12",
+    "@storybook/addon-actions": "~6.3.12",
+    "@storybook/addon-essentials": "~6.3.12",
     "@storybook/addon-postcss": "^2.0.0",
-    "@storybook/react": "^6.3.12",
+    "@storybook/react": "~6.3.12",
     "@types/react": "^17.0.34",
     "@types/react-helmet": "^6.1.4",
     "@types/react-router-hash-link": "^2.4.4",
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "react-helmet": "^6.1.0",
-    "react-router-dom": "^6.0.2",
+    "react-router-dom": "^5.3.0",
     "react-router-hash-link": "^2.4.3"
   }
 }

--- a/src/components/breadcrumbs/breadcrumbs.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from "react";
+import { Link } from "../link";
 import "./breadcrumbs.css";
 
 export type BreadcrumbsProps = {
@@ -34,9 +35,9 @@ export function Breadcrumbs({ nodes, separator = ">" }: BreadcrumbsProps) {
                 </span>
               )}
               <li className={["breadcrumbs__list-item", currentNode].join(" ")}>
-                <a className="breadcrumbs__link" href={node.path}>
+                <Link className="breadcrumbs__link" uri={node.path}>
                   {node.displayName}
-                </a>
+                </Link>
               </li>
             </Fragment>
           );

--- a/src/stories/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/stories/breadcrumbs/breadcrumbs.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 import { Breadcrumbs } from "../../index";
 import "./styles.css";
 import { nodesTrail, svg } from "./mock";
+import reactRouterDecorator from "../../../.storybook/decorators/react-router";
 
 export default {
   title: "Components/Breadcrumbs",
@@ -17,18 +18,21 @@ const Template: ComponentStory<typeof Breadcrumbs> = (args) => (
 );
 
 export const Primary = Template.bind({});
+Primary.decorators = [reactRouterDecorator];
 Primary.args = {
   nodes: nodesTrail,
   separator: "/",
 };
 
 export const SVG = Template.bind({});
+SVG.decorators = [reactRouterDecorator];
 SVG.args = {
   nodes: nodesTrail,
   separator: svg,
 };
 
 export const Emoji = Template.bind({});
+Emoji.decorators = [reactRouterDecorator];
 Emoji.args = {
   nodes: nodesTrail,
   separator: "👉",

--- a/src/stories/link/link.stories.tsx
+++ b/src/stories/link/link.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentStory, ComponentMeta } from "@storybook/react";
+import reactRouterDecorator from "../../../.storybook/decorators/react-router";
 
 import { Link } from "../../index";
 import "./link.css";
@@ -15,6 +16,7 @@ export default {
 const Template: ComponentStory<typeof Link> = (args) => <Link {...args} />;
 
 export const Primary = Template.bind({});
+Primary.decorators = [reactRouterDecorator];
 Primary.args = {
   title: "Example link title",
   text: "Example link",


### PR DESCRIPTION
### Compatibility Changes
I've rolled back react-router and storybook to provide compatibility with our React Base, which will be the main consumer of this repo.

Ideally, react-router wouldn't be required by this package and instead we would allow the "Link" implementation to be supplied by the consumer. However, that adds complexity to using the component-library. Perhaps this could be a topic of further discussion down the line, as we could create a "pure" component library and then provide a separate compatibility package for the react base project which wraps up the "pure" components in more abstract components which handle e.g. passing through react-router or converting an array of nodes into a list of breadcrumbs.

### React-Router decorator
Again, this could be subject to change after a discussion of the above, but while we depend on react-router we need storybook to be able to handle routing and provide "actions" when links are clicked within storybook.

### Breadcrumb implementation
The breadcrumb now uses the <Link> component rather than the <a> component so that any client-side routing is adhered to.